### PR TITLE
Make openvpnserv2's openvpn respawn tests optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Usage
 
 The main script tests only one VPN connection:
 ::
-  Usage: Test-Openvpn.ps1 -Config <openvpn-config-file> -Ping <hosts> [-Openvpn <openvpn-exe>] [-Gui <openvpn-gui-exe>] [-TestCmdexe] [-TestService] [-TestGui] [-Help]
+  Usage: Test-Openvpn.ps1 -Config <openvpn-config-file> -Ping <hosts> [-Openvpn <openvpn-exe>] [-Gui <openvpn-gui-exe>] [-TestCmdexe] [-TestService] [-TestRespawn] [-TestGui] [-Help]
   
   Parameters:
      -Openvpn     Path to openvpn.exe (defaults to C:\Program Files\OpenVPN\bin\openvpn.exe)
@@ -19,12 +19,14 @@ The main script tests only one VPN connection:
      -Config      Path to the OpenVPN configuration file
      -Ping        Target host(s) inside VPN to ping (should succeed). Separate multiple entries
                   with commas.
+     -Suspend     Test suspend and resume [UNIMPLEMENTED]
      -TestCmdexe  Test connection from the command-line
      -TestGui     Test OpenVPN-GUI
      -TestService Test openvpnserv2.exe
+     -TestRespawn Test if openvpnserv2 is able to respawn a dead connection properly
      -Help        Display this help
   
-  Example: .\Test-Openvpn -Config "C:\Program Files\OpenVPN\config\company.ovpn" -Ping 192.168.40.7 -TestCmdexe -TestService -TestGui
+  Example: .\Test-Openvpn.ps1 -Config "C:\Program Files\OpenVPN\config\company.ovpn" -Ping 192.168.40.7 -TestCmdexe -TestService -TestGui
 
 To verify that the connections do not succeed because of a bug or by accident,
 -Ping a fake IP that can only fail.

--- a/test-openvpn.ps1
+++ b/test-openvpn.ps1
@@ -5,12 +5,13 @@
     [array]$Ping,
     [switch]$TestCmdexe,
     [switch]$TestService,
+    [switch]$TestRespawn,
     [switch]$TestGui,
     [switch]$Help
 )
 
 Function Show-Usage {
-    Write-Host "Usage: Test-Openvpn.ps1 -Config <openvpn-config-file> -Ping <host> [-Openvpn <openvpn-exe>] [-Gui <openvpn-gui-exe>] [-TestCmdexe] [-TestService] [-TestGui] [-Help]"
+    Write-Host "Usage: Test-Openvpn.ps1 -Config <openvpn-config-file> -Ping <hosts> [-Openvpn <openvpn-exe>] [-Gui <openvpn-gui-exe>] [-TestCmdexe] [-TestService] [-TestRespawn] [-TestGui] [-Help]"
     Write-Host
     Write-Host "Parameters:"
     Write-Host "   -Openvpn     Path to openvpn.exe (defaults to C:\Program Files\OpenVPN\bin\openvpn.exe)"
@@ -21,6 +22,7 @@ Function Show-Usage {
     Write-Host "   -TestCmdexe  Test connection from the command-line"
     Write-Host "   -TestGui     Test OpenVPN-GUI"
     Write-Host "   -TestService Test openvpnserv2.exe"
+    Write-Host "   -TestRespawn Test if openvpnserv2 is able to respawn a dead connection properly"
     Write-Host "   -Help        Display this help"
     Write-Host
     Write-Host "Example: .\Test-Openvpn.ps1 -Config ""C:\Program Files\OpenVPN\config\company.ovpn"" -Ping 192.168.40.7 -TestCmdexe -TestService -TestGui"
@@ -165,9 +167,11 @@ Function Test-Service {
 
     Start-Service OpenVPNService
     Check-Connectivity "openvpnserv2" $ping
-    # Test if openvpn.exe is respawned correctly on forced kill
-    Stop-Openvpn
-    Check-connectivity "openvpnserv2-respawn" $ping
+
+    if ($TestRespawn) {
+        Stop-Openvpn
+        Check-connectivity "openvpnserv2-respawn" $ping
+    }
     Stop-Service OpenVPNService
 
     foreach ($move in $moved) {


### PR DESCRIPTION
Killing openvpn.exe processes launched by openvpnserv2.exe is a good way
to ensure that openvpnserv2 is able to relaunched crashed connections.
Right now, however, that may cause issues with IPv6 route setup for
subsequent openvpn connections, so the behavior is made optional.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>