### PR TITLE
Add basic installer testing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,15 @@ can test OpenVPN in cmd.exe, OpenVPN-GUI and  openvpnserv2. Success and failure
 are based on simple ping tests to one or more hosts. A typical use-case for
 these scripts is smoke-testing an installer prior to a major release.
 
-Usage
-=====
+The Test-Installer.ps1 script currently tests how OpenVPN reinstalls and full
+uninstall/install cycles affect the service states. The script was motivated
+by the need to test the changes in openvpn-build pull request #80. Later the
+script can be extended to other things and integrated with Test-OpenVPN.ps1.
 
-The main script tests only one VPN connection:
+Using test-openvpn.ps1
+======================
+
+Test-Openvpn.ps1 tests only one VPN connection:
 ::
   Usage: Test-Openvpn.ps1 -Config <openvpn-config-file> -Ping <hosts> [-Openvpn <openvpn-exe>] [-Gui <openvpn-gui-exe>] [-TestCmdexe] [-TestService] [-TestRespawn] [-TestGui] [-Help]
   
@@ -51,29 +56,27 @@ to your (test) OpenVPN configuration file. This approach will only work when
 the script is launched with -TestCmdexe.
 
 Scope of the tests
-==================
+------------------
 
-OpenVPN inside cmd.exe
-----------------------
-
-Connect -> ping test -> disconnect
-
-OpenVPN GUI
------------
+OpenVPN inside cmd.exe:
 
 Connect -> ping test -> disconnect
 
-Openvpnserv2
-------------
+OpenVPN GUI:
+
+Connect -> ping test -> disconnect
+
+Openvpnserv2:
 
 Connect -> ping test -> kill openvpn -> openvpnserv2 restart openvpn -> ping test -> disconnect
 
 Warnings
-========
+--------
 
-The script brutally kills every openvpn.exe and openvpn-gui.exe process it
-finds at startup, as well as stops OpenVPNService. Similarly, when it is done
-with each test, it in general kills the processes without signaling them.
+The test-openvpn.ps1 script brutally kills every openvpn.exe and openvpn-gui.exe
+process it finds at startup, as well as stops OpenVPNService. Similarly, when it
+is done with each test, it in general kills the processes without signaling
+them.
 
 The openvpnserv2-based tests move irrelevant .ovpn files out of the way to the
 current working directory before launching the service. After the test the
@@ -82,3 +85,19 @@ some .ovpn files may have to be moved back manually.
 
 While this script seems to work fine, it can potentially cause issues. At
 minimum make sure that your VPN configurations are backed up.
+
+Using Test-Installer.ps1
+========================
+
+Test-Installer.ps1 is straightforward to use:
+::
+  Usage: Test-Installer.ps1 -Installer <installer-file> [-Verbose] [-TestUpgrade] [-TestCleanInstall] [-Help]
+  
+  Parameters:
+     -Installer        Path to the OpenVPN installer you wish to test
+     -Verbose          Show what is happening, even if there is nothing
+	                   noteworthy to report
+     -TestUpgrade      Test reinstalling on top of old installation
+     -TestCleanInstall Test full uninstall -> install cycle
+     -Help             Display this help
+	 

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,12 @@ uninstall/install cycles affect the service states. The script was motivated
 by the need to test the changes in openvpn-build pull request #80. Later the
 script can be extended to other things and integrated with Test-OpenVPN.ps1.
 
+The Test-Installer.ps1 script will use the management interface to cleanly shut
+down OpenVPN instances launched from cmd.exe. Similarly, in OpenVPNService-based
+tests, OpenVPN instances are cleanly shut down using exit-events implemented in
+OpenVPNService itself. However, there's currently no way to signal OpenVPN GUI
+to shut down itself, or the OpenVPN instances it manages.
+
 Using test-openvpn.ps1
 ======================
 
@@ -48,13 +54,6 @@ Note that right now OpenVPN might mess up IPv6 routes if OpenVPN instances are
 killed forcibly, as this script does in most cases. This can cause IPv6 ping
 tests to fail after an initial connection.
 
-If you want the script to signal openvpn.exe before killing after the test, add
-
-    management 127.0.0.1 58581
-
-to your (test) OpenVPN configuration file. This approach will only work when
-the script is launched with -TestCmdexe.
-
 Scope of the tests
 ------------------
 
@@ -74,9 +73,9 @@ Warnings
 --------
 
 The test-openvpn.ps1 script brutally kills every openvpn.exe and openvpn-gui.exe
-process it finds at startup, as well as stops OpenVPNService. Similarly, when it
-is done with each test, it in general kills the processes without signaling
-them.
+process it finds at startup, as well as stops OpenVPNService. As described
+above, in OpenVPN GUI tests OpenVPN GUI and the OpenVPN instances it manages
+are killled without signaling.
 
 The openvpnserv2-based tests move irrelevant .ovpn files out of the way to the
 current working directory before launching the service. After the test the
@@ -96,7 +95,7 @@ Test-Installer.ps1 is straightforward to use:
   Parameters:
      -Installer        Path to the OpenVPN installer you wish to test
      -Verbose          Show what is happening, even if there is nothing
-	                   noteworthy to report
+                       noteworthy to report
      -TestUpgrade      Test reinstalling on top of old installation
      -TestCleanInstall Test full uninstall -> install cycle
      -Help             Display this help

--- a/Test-Installer.ps1
+++ b/Test-Installer.ps1
@@ -1,0 +1,129 @@
+﻿Param (
+    [string]$Installer,
+    [switch]$TestUpgrade,
+    [switch]$TestCleanInstall,
+    [switch]$Verbose,
+    [switch]$Help
+)
+
+Function Show-Usage {
+    Write-Host "Usage: Test-Installer.ps1 -Installer <installer-file> [-Verbose] [-TestUpgrade] [-TestCleanInstall] [-Help]"
+    Write-Host
+    Write-Host "Parameters:"
+    Write-Host "   -Installer        Path to the OpenVPN installer you wish to test"
+    Write-Host "   -Verbose          Show what is happening, even if there is nothing noteworthy to report"
+    Write-Host "   -TestUpgrade      Test reinstalling on top of old installation"
+    Write-Host "   -TestCleanInstall Test full uninstall -> install cycle"
+    Write-Host "   -Help             Display this help"
+    exit 1
+}
+
+if ($Help) {
+    Show-Usage
+}
+
+if (! $installer) {
+    Show-Usage
+}
+
+if (! (Test-Path $installer -PathType leaf)) {
+    Write-Host "ERROR: Invalid file!"
+    Show-Usage
+}
+
+Function Write-IfVerbose($message) {
+    if ($Verbose) {
+        Write-Host $message
+    }
+}
+
+Function Get-ServiceStates {
+    $service_states = New-Object –TypeName PSObject
+    $services = "OpenVPNService", "OpenVPNServiceInteractive", "OpenVPNServiceLegacy"
+    foreach ($service in $services) {
+        Add-Member -InputObject $service_states -NotePropertyName "${service}_Status" -NotePropertyValue ([string](Get-Service $service).Status)
+        Add-Member -InputObject $service_states -NotePropertyName "${service}_StartMode"-NotePropertyValue ([string](Get-WmiObject -Class Win32_Service -Property StartMode -Filter "Name='$service'").Startmode)
+    }
+    return $service_states
+}
+
+function Run-Installer($installer) {
+    Write-IfVerbose "Running OpenVPN installer"
+
+    & $installer /S
+
+    # Wait for the installer to finish. It would be cleaner to just use
+    #
+    # Start-Process -Wait -FilePath $installer -ArgumentList "/S"
+    #
+    # but that generates a warning popup which the user has to manually
+    # skip.
+    $processname = [string](Get-ChildItem $installer).BaseName
+    while (Get-Process -ProcessName $processname -ErrorAction Ignore) {
+        Start-Sleep -Seconds 1
+    }
+    Write-IfVerbose "Install finished"
+}
+
+function Run-Uninstaller {
+    Write-IfVerbose "Running OpenVPN uninstaller"
+
+    # Uninstaller seems to fork immediately, so launching it with
+    #
+    # Start-Process -Wait -FilePath $uninstaller -ArgumentList "/S"
+    #
+    # Exits immediately. Unlike the installer, running the uninstaller
+    # from within Start-Process does not trigger any warnings.
+    #
+    & 'C:\Program Files\OpenVPN\Uninstall.exe' /S
+
+    # Due to above just sleep a while
+    Start-Sleep -Seconds 7
+
+    Write-IfVerbose "Uninstall finished"
+}
+
+function Compare-ServiceStates($service_states_before,$service_states_after) {
+
+    # Create an arraylist with all the service state property names
+    $service_state_names = [System.Collections.ArrayList]@()
+    foreach ($property in ($service_states_before|Get-Member -Type NoteProperty)) {
+        $service_state_names.Add(([string]$property.Name)) > $null
+    }
+
+    # Compare states before and after install
+    $no_changes = $true
+    foreach ($property_name in $service_state_names) {
+        $before = $service_states_before.$property_name
+        $after = $service_states_after.$property_name
+        if ($before -ne $after) {
+            Write-Host "${property_name} has changed from ${before} to ${after}"
+            $no_changes = $false
+        }
+    }
+
+    if ($no_changes) {
+        Write-IfVerbose "No changes during install"
+    }
+
+}
+
+if ($TestUpgrade) {
+    $service_states_before = Get-ServiceStates
+    Run-Installer $installer
+    $service_states_after = Get-ServiceStates
+
+    # To verify that the service state check works, use
+    #
+    # $service_states_after.OpenVPNService_StartMode = "Changed"
+
+    Compare-ServiceStates $service_states_before $service_states_after
+}
+
+if ($TestCleanInstall) {
+    $service_states_before = Get-ServiceStates
+    Run-Uninstaller
+    Run-Installer $installer
+    $service_states_after = Get-ServiceStates
+    Compare-ServiceStates $service_states_before $service_states_after
+}

--- a/test-openvpn.ps1
+++ b/test-openvpn.ps1
@@ -144,7 +144,7 @@ Function Test-Cmdexe {
 
     $bat = "${Configname}.bat"
     $pidfile = "${cwd}\${Configname}.pid"
-    Set-Content -Path "${bat}" -Value """${Openvpn}"" --config ""${config}"" --writepid ""${pidfile}"" --cd ""${Configdir}"" & exit"
+    Set-Content -Path "${bat}" -Value """${Openvpn}"" --management 127.0.0.1 58581 --config ""${config}"" --writepid ""${pidfile}"" --cd ""${Configdir}"" & exit"
     Start-Process -FilePath $env:ComSpec -ArgumentList "/c", "start", "${bat}"
     Check-Connectivity "cmdexe" $ping
     Stop-Management


### PR DESCRIPTION
Right now installer testing is limited to comparing the state of all OpenVPN services before and after install, and reporting these difference to the user. Reinstalls as well as full uninstall/install cycles are supported.