### PR TITLE
Use openvpn-gui and interactive service to start VPN connections

### DIFF
--- a/Start-AWSTest.ps1
+++ b/Start-AWSTest.ps1
@@ -120,7 +120,10 @@ function Remove-Instance([string]$InstId) {
 }
 
 function Get-Logs($IP, $Sess) {
-    Invoke-Command -Session $sess -ScriptBlock { Compress-Archive -Path "*.log" -DestinationPath "$HOME\openvpn-logs.zip" }
+    Invoke-Command -Session $sess -ScriptBlock {
+        Copy-Item -Path "$ENV:UserProfile\OpenVPN\log\*.log" -Destination "." -Recurse
+        Compress-Archive -Path "*.log" -DestinationPath "$HOME\openvpn-logs.zip"
+    }
 
     scp -i $SSH_KEY administrator@${IP}:openvpn-logs.zip .
 }
@@ -137,7 +140,7 @@ try {
 
     Install-MSI -IP $ip -Sess $sess
     Test-Install -IP $ip -Sess $sess
-    $exitcode = Invoke-Command -Session $sess -FilePath Start-LocalTest.ps1 -ArgumentList @($Driver, "C:\TA\ca.crt", "C:\TA\t_client.crt", "C:\TA\t_client.key", $Tests, 1)
+    $exitcode = Invoke-Command -Session $sess -FilePath Start-LocalTest.ps1 -ArgumentList @($Driver, 1, "C:/TA/ca.crt", "C:/TA/t_client.crt", "C:/TA/t_client.key", $Tests, 1)
 }
 catch {
     Write-Host $_


### PR DESCRIPTION
This enables more comprehensive testing of Windows client.

Configuration is now always stored in .ovpn file in $ENV:UserProfile\\OpenVPN\config directory.

When .\Start-LocalTest.ps1 is launched with -UseGUI 1:

 - connection profiles are refreshed in -gui by calling openvpn-gui.exe --command rescan

 - connection is started with openvpn-gui.exe --connect <config>

 - connection is stopped with openvpn-gui.exe --command disconnect <config>

Signed-off-by: Lev Stipakov <lev@openvpn.net>