### PR TITLE
Add DNS tests

### DIFF
--- a/Start-LocalTest.ps1
+++ b/Start-LocalTest.ps1
@@ -57,9 +57,10 @@ dev tun
 proto tcp4
 remote $REMOTE
 port 51194
+setenv UV_WANT_DNS dns
 "@
-        Ping4Hosts=$PING4_HOSTS_1
-        Ping6Hosts=$PING6_HOSTS_1
+        Ping4Hosts=$PING4_HOSTS_1 + @("ping4.open.vpn")
+        Ping6Hosts=$PING6_HOSTS_1 + @("ping6.open.vpn")
     }
     "1a" = @{
         Title="tcp*6* / p2pm / top net30"
@@ -70,9 +71,10 @@ proto tcp6-client
 remote $REMOTE
 port 51194
 server-poll-timeout 10
+setenv UV_WANT_DNS dhcp
 "@
-        Ping4Hosts=$PING4_HOSTS_1
-        Ping6Hosts=$PING6_HOSTS_1
+        Ping4Hosts=$PING4_HOSTS_1 + @("ping4.open.vpn")
+        Ping6Hosts=$PING6_HOSTS_1 + @("ping6.open.vpn")
     }
     "2" = @{
         Title="udp / p2pm / top net30"


### PR DESCRIPTION
OpenVPN sets DNS in various ways:

 - DHCP when using IPv4 DNS and tap-windows6
 - Adapter-specific registry keys when using --dhcp-option and DCO or tap-windows6 and IPv6 DNS
 - NRPT registry keys when using DCO and --dns

This adds IPv4/V6 pings via domain names to the two tests (it doesn't really matter which ones as long as they run with both drivers) and two ways to set DNS servers (one with --dhcp-option and another one with --dns).

This should cover all ways of setting DNS for all supported drivers.