### PR TITLE
Start-AWSTest: Handle slow instance creation

### DIFF
--- a/Start-AWSTest.ps1
+++ b/Start-AWSTest.ps1
@@ -88,13 +88,20 @@ function Start-TestMachine() {
         -SecurityGroupId $SECURITY_GROUPS).Instances[0].InstanceId
 
     Write-Host "Instance $instId started"
+    Start-Sleep 5
 
     while ($true) {
-        $status = (Get-EC2InstanceStatus -InstanceId $instId).Status.Status
-        Write-Host "Checking status... " $status
-        if ($status -eq "ok") {
-            break
+        try {
+            $status = (Get-EC2InstanceStatus -InstanceId $instId).Status.Status
+            Write-Host "Checking status... " $status
+            if ($status -eq "ok") {
+                break
+            }
         }
+        catch [Amazon.EC2.AmazonEC2Exception] {
+            Write-Host "Exception: $_"
+        }
+
         Start-Sleep 5
     }
 


### PR DESCRIPTION
When New-EC2Instance completes, Get-EC2InstanceStatus is not guaranteed so succeed. Sometimes it takes some time before the instance actually exists. In this case the whole script currently fails. Which leads to dangling instances when run from GHA.

Instead try harder.