### PR TITLE
Start-AWSTest: check if MSI signature is valid before installation

### DIFF
--- a/Start-AWSTest.ps1
+++ b/Start-AWSTest.ps1
@@ -118,6 +118,12 @@ function Install-MSI($IP, $Sess) {
     Write-Host "Install MSI"
     $msiFileName = Split-Path "$MSI_PATH" -leaf
     Invoke-Command -Session $Sess -ArgumentList $msiFileName -ScriptBlock {
+        $sig = Get-AuthenticodeSignature -FilePath "$HOME\$args"
+        if ($sig.Status -ne 'Valid') {
+            Write-Host "MSI signature status: $($sig.Status)"
+            Write-Error "MSI signature is not valid" -ErrorAction Stop
+        }
+
         Start-Process msiexec.exe -Wait -ArgumentList @("/I", "$HOME\$args", "/quiet", "/L*V", "install.log")
     }
 }


### PR DESCRIPTION
It might happen during the build that installer is not signed
And it is hard to detect because of huge build output
This check helps detect missing or not valid MSI signature