### PR TITLE
Replace CA/Cert/Key with inline file

### DIFF
--- a/Start-AWSTest.ps1
+++ b/Start-AWSTest.ps1
@@ -3,6 +3,7 @@
 
 param (
     [string]$SSH_KEY = "c:\Users\lev\.ssh\openvpn2_win_ta",
+    [string]$CONFIG_FILE = ".\t_client.inline",
     [string]$MSI_PATH = "OpenVPN-2.6git-amd64.msi",
 
     [ValidateSet("Default", "OvpnDco", "TapWindows6", "All")]
@@ -159,7 +160,8 @@ try {
 
     Install-MSI -IP $ip -Sess $sess
     Test-Install -IP $ip -Sess $sess
-    $exitcode = Invoke-Command -Session $sess -FilePath Start-LocalTest.ps1 -ArgumentList @($Driver, 1, "C:/TA/ca.crt", "C:/TA/t_client.crt", "C:/TA/t_client.key", $Tests, 1)
+    scp -i $SSH_KEY "$CONFIG_FILE" administrator@${IP}:C:/TA/t_client.inline
+    $exitcode = Invoke-Command -Session $sess -FilePath Start-LocalTest.ps1 -ArgumentList @($Driver, 1, "C:/TA/t_client.inline", $Tests, 1)
 }
 catch {
     Write-Host "Test failed with exception: $_"

--- a/Start-LocalTest.ps1
+++ b/Start-LocalTest.ps1
@@ -7,9 +7,7 @@ param (
     # use openvpn-gui and service to start/stop connections
     [int]$UseGUI = 0,
 
-    [string]$CA = "c:/Temp/openvpn2_ta/ca.crt",
-    [string]$CERT = "c:/Temp/openvpn2_ta/lev-tclient.crt",
-    [string]$KEY = "c:/Temp/openvpn2_ta/lev-tclient.key",
+    [string]$Config = "c:/Temp/t_client.inline",
 
     [string[]]$Tests = "All",
 
@@ -27,10 +25,7 @@ $REMOTE = "conn-test-server.openvpn.org"
 
 $BASE_P2MP=@"
 client
-tls-cert-profile insecure
-ca $CA
-cert $CERT
-key $KEY
+config $Config
 remote-cert-tls server
 verb 3
 setenv UV_NOCOMP 1
@@ -132,10 +127,7 @@ port 51195
         Driver="OvpnDco"
         Conf=@"
 client
-tls-cert-profile insecure
-ca $CA
-cert $CERT
-key $KEY
+config $Config
 remote-cert-tls server
 verb 3
 dev tun
@@ -151,10 +143,7 @@ push-peer-info
         Driver="TapWindows6"
         Conf=@"
 client
-tls-cert-profile insecure
-ca $CA
-cert $CERT
-key $KEY
+config $Config
 remote-cert-tls server
 verb 3
 dev tun


### PR DESCRIPTION
This file as generated by easy-rsa v3 contains the whole authentication config. So this makes our lives easier.

While here also change it so that we do not assume that the files are baked into the AMI. This is cumbersome. Instead the caller should provide the authentication data.